### PR TITLE
Support for ESP32 and ESP32C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ For more information check out the [datasheet](https://www.ti.com/lit/ds/symlink
 
 The CC1101 module uses the SPI interface for communication. The SI, SO, SCLK pins should be connected to dedicated SPI pins on your Arduino board. The CSn can be connected to any digital pin.
 
+On an ESP32, any GPIOs can be used, you can specify alternate ones in the constructor.
+
 The CC1101 exposes also two general purpose pins (GDO0, GDO2) which can be used to interrupt the MCU on certain events (e.g. RX FIFO is filled). They are optional and not required for proper work.
 
 
@@ -183,4 +185,5 @@ Enables / disables CRC calculation in TX and CRC checking in RX.
 
 ##
 
-The library was tested on [Teensy 4.0](https://www.pjrc.com/store/teensy40.html) and [Arduino Pro Mini 3.3V](https://docs.arduino.cc/retired/boards/arduino-pro-mini/).
+The library was tested on [Teensy 4.0](https://www.pjrc.com/store/teensy40.html), [Arduino Pro Mini 3.3V](https://docs.arduino.cc/retired/boards/arduino-pro-mini/),
+[Wemos D1 Mini ESP32](https://docs.platformio.org/en/stable/boards/espressif32/wemos_d1_mini32.html), and [ESP32C3 Super Mini](https://www.espboards.dev/esp32/esp32-c3-super-mini/).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information check out the [datasheet](https://www.ti.com/lit/ds/symlink
 
 The CC1101 module uses the SPI interface for communication. The SI, SO, SCLK pins should be connected to dedicated SPI pins on your Arduino board. The CSn can be connected to any digital pin.
 
-On an ESP32, any GPIOs can be used, you can specify alternate ones in the constructor.
+On an ESP32 any GPIOs can be used, you can specify alternate ones in the constructor.
 
 The CC1101 exposes also two general purpose pins (GDO0, GDO2) which can be used to interrupt the MCU on certain events (e.g. RX FIFO is filled). They are optional and not required for proper work.
 
@@ -185,5 +185,10 @@ Enables / disables CRC calculation in TX and CRC checking in RX.
 
 ##
 
-The library was tested on [Teensy 4.0](https://www.pjrc.com/store/teensy40.html), [Arduino Pro Mini 3.3V](https://docs.arduino.cc/retired/boards/arduino-pro-mini/),
-[Wemos D1 Mini ESP32](https://docs.platformio.org/en/stable/boards/espressif32/wemos_d1_mini32.html), and [ESP32C3 Super Mini](https://www.espboards.dev/esp32/esp32-c3-super-mini/).
+The library was tested on the following boards:
+
+ * [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
+ * [Arduino Pro Mini 3.3V](https://docs.arduino.cc/retired/boards/arduino-pro-mini/),
+ * [Wemos D1 Mini ESP32](https://docs.platformio.org/en/stable/boards/espressif32/wemos_d1_mini32.html)
+ * [ESP32C3 Super Mini](https://www.espboards.dev/esp32/esp32-c3-super-mini/).
+

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -121,6 +121,19 @@ enum AddressFilteringMode {
 
 class Radio {
  public:
+#ifdef ESP32
+  Radio(uint8_t cs, uint8_t clk = PIN_UNUSED, uint8_t miso = PIN_UNUSED, uint8_t mosi = PIN_UNUSED, uint8_t gd0 = PIN_UNUSED, uint8_t gd2 = PIN_UNUSED)
+    : cs(cs),
+      gd0(gd0),
+      gd2(gd2),
+      clk(clk),
+      miso(miso),
+      mosi(mosi),
+      spiSettings(CC1101_SPI_MAX_FREQ,
+                  CC1101_SPI_DATA_ORDER,
+                  CC1101_SPI_DATA_MODE) {}
+
+#else
   Radio(uint8_t cs, uint8_t gd0 = PIN_UNUSED, uint8_t gd2 = PIN_UNUSED)
     : cs(cs),
       gd0(gd0),
@@ -128,6 +141,7 @@ class Radio {
       spiSettings(CC1101_SPI_MAX_FREQ,
                   CC1101_SPI_DATA_ORDER,
                   CC1101_SPI_DATA_MODE) {}
+#endif
 
   Status begin(Modulation mod = MOD_ASK_OOK,
                double freq = 433.5,
@@ -187,6 +201,7 @@ class Radio {
   void saveStatus(byte status);
 
   uint8_t cs, gd0, gd2;
+  uint8_t clk, miso, mosi;
   SPISettings spiSettings;
 
   State currentState = STATE_IDLE;


### PR DESCRIPTION
ESP32 supports SPI on arbitrary pins, so allow this in the constructor for ESP32. Also handle a quirk with ESP32C3 where it's not possible to poll MISO whilst the SPI peripheral is enabled.
