### PR TITLE
Add receive timeout, example, and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Returns
 
 #### receive
 ```cpp
-Status receive(uint8_t *data, size_t length, size_t *read = nullptr, uint8_t addr = 0)
+Status receive(uint8_t *data, size_t length, size_t *read = nullptr, uint8_t addr = 0, uint32_t timeout = 100)
 ```
-Receives the data. The `read` parameter indicates the number of bytes actually received. The `addr` parameter is used when the address filtering mode is enabled.
+Receives the data. The `read` parameter indicates the number of bytes actually received. The `addr` parameter is used when the address filtering mode is enabled. `timeout` is the time in millisecond to wait for the packets.
 
 Returns
 * `STATUS_LENGTH_TOO_BIG` if the `length` parameter is greater than 255

--- a/examples/Bidirectional_link/Bidirectional_link.ino
+++ b/examples/Bidirectional_link/Bidirectional_link.ino
@@ -1,0 +1,121 @@
+#include <Arduino.h>
+#include <cc1101.h>
+
+
+using namespace CC1101;
+
+Radio radio(/* cs pin */ 10);
+
+uint8_t tx_channel = 2; // switch tx and rx channels on the second device to test cross-channel communication
+uint32_t rx_channel = 1;
+uint8_t device_id = 0x99; // set to 0 for broadcast, or any other value for address filtering of incoming packets
+
+
+const uint32_t tx_delay = 3000;
+uint32_t _tx_delay = tx_delay; // variable tx delay 
+uint32_t tx_timer = 0;
+int tx_counter = 0;
+
+
+
+void setup() {
+    Serial.begin(115200);
+    delay(3000);
+    Serial.println(F("Starting ..."));
+    delay(1000);
+
+
+    if (radio.begin() == STATUS_CHIP_NOT_FOUND) {
+        Serial.println(F("Chip not found!"));
+        while (true) {
+            delay(5000);
+            Serial.println(F("Chip not found!"));
+        }
+    }
+
+    radio.setModulation(MOD_ASK_OOK);
+    radio.setFrequency(433.97);
+    radio.setDataRate(10);
+    radio.setOutputPower(10);
+    //radio.setRxBandwidth(200);
+    if (radio.setFrequencyDeviation(25) != STATUS_OK) {  // no effect in MOD_ASK_OOK
+        Serial.println(F("Invalid frequency deviation!"));
+    }
+
+    radio.setPacketLengthMode(PKT_LEN_MODE_VARIABLE);
+    radio.setAddressFilteringMode(ADDR_FILTER_MODE_CHECK_BC_0); // address filtering with 0 as broadcast address, so that we can test both unicast and broadcast communication
+    radio.setPreambleLength(64);
+    radio.setSyncWord(0x1234);
+    radio.setSyncMode(SYNC_MODE_16_16);
+    radio.setCrc(true);
+    radio.setDataWhitening(true);
+    radio.setManchester(false);
+    radio.setFEC(false);
+}
+
+void loop() {
+    rx_data(100);
+
+    if ((millis() - tx_timer) > tx_delay) {
+        tx_data();
+        tx_timer = millis();
+    }
+}
+
+
+float readTemperature() {
+    return 0.0; //dummy value
+}
+
+
+
+void tx_data() {
+    float temp = readTemperature();
+    String data = "Hello#" + String(tx_counter++) + " from ch " + String(tx_channel) + " temp " + String(temp, 2) + "°C";
+
+    Serial.print(F("Transmitting: "));
+    Serial.print(data);
+    Serial.print(F(" "));
+    radio.setChannel(tx_channel);
+    Status status = radio.transmit(reinterpret_cast<const uint8_t *>(data.c_str()), data.length(), device_id);
+    if (status == STATUS_OK) {
+        Serial.println(F("[OK]"));
+    } else {
+        Serial.print(F("[ERROR "));
+        Serial.print(status);
+        Serial.println(F("]"));
+    }
+
+    _tx_delay = tx_delay - (temp * 10); // decrease tx delay as temperature increases, just so that all nodes don't transmit at the same time
+}
+
+void rx_data(uint32_t timeout) {
+    char buff[256];
+    size_t read;
+
+    radio.setChannel(rx_channel);
+    Status status = radio.receive(reinterpret_cast<uint8_t *>(buff), sizeof(buff) - 1, &read, device_id, timeout);
+
+    if (status == STATUS_OK) {
+        buff[read] = '\0';
+
+        Serial.print(F("Data: "));
+        Serial.println(buff);
+
+        Serial.print(F("Length: "));
+        Serial.println(read);
+
+        Serial.print(F("RSSI: "));
+        Serial.print(radio.getRSSI());
+        Serial.println(F(" dBm"));
+
+        Serial.print(F("LQI: "));
+        Serial.println(radio.getLQI());
+        Serial.println();
+    } else if (status == STATUS_CRC_MISMATCH) {
+        Serial.println(F("CRC mismatch!"));
+    } else if (status != STATUS_TIMEOUT) {
+        Serial.print(F("Error: "));
+        Serial.println(status);
+    }
+}

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -59,8 +59,10 @@ void Radio::setRegs() {
   /* Automatically calibrate when going from IDLE to RX or TX. */
   writeRegField(CC1101_REG_MCSM0, 1, 5, 4);
 
-  /* Enable append status */
-  writeRegField(CC1101_REG_PKTCTRL1, 1, 2, 2);
+
+  
+  /* /EnableDisable append status */
+  writeRegField(CC1101_REG_PKTCTRL1, CC1101_APPEND_STATUS, 2, 2);
 
   /* Disable data whitening. */
   setDataWhitening(false);
@@ -472,7 +474,7 @@ Status Radio::transmit(uint8_t *data, size_t length, uint8_t addr) {
   return ret;
 }
 
-Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) {
+Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr, uint32_t timeout) {
   if (length > 255) {
     return STATUS_LENGTH_TOO_BIG;
   }
@@ -491,19 +493,43 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
       curPktLen = this->pktLen;
     break;
     case PKT_LEN_MODE_VARIABLE:
-      waitForBytesInFifo();
+    {
+      uint32_t start = millis();
+      uint8_t bytes = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      while (bytes == 0) {
+        if (timeout && (millis() - start) >= timeout) {
+          setState(STATE_IDLE);
+          return STATUS_TIMEOUT;
+        }
+        delayMicroseconds(15);
+        yield();
+        bytes = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      }
       curPktLen = readReg(CC1101_REG_FIFO);
       bytesRead++;
+    }
     break;
   }
 
   uint8_t dataRead = 0, dataLength = curPktLen;
 
   if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
-    waitForBytesInFifo();
-    (void)readReg(CC1101_REG_FIFO);
+    {
+      uint32_t start = millis();
+      uint8_t bytes = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      while (bytes == 0) {
+        if (timeout && (millis() - start) >= timeout) {
+          setState(STATE_IDLE);
+          return STATUS_TIMEOUT;
+        }
+        delayMicroseconds(15);
+        yield();
+        bytes = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      }
+      (void)readReg(CC1101_REG_FIFO);
     bytesRead++;
     dataLength--;
+    }
   }
 
   if (dataLength > length) {
@@ -517,14 +543,36 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   */
   if (dataLength <= (uint8_t)(CC1101_FIFO_SIZE - bytesRead)) {
     do {
+      uint32_t start = millis();
       delayMicroseconds(15);
       yield();
-      bytesInFifo = waitForBytesInFifo();
+      bytesInFifo = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      while (bytesInFifo == 0) {
+        if (timeout && (millis() - start) >= timeout) {
+          setState(STATE_IDLE);
+          return STATUS_TIMEOUT;
+        }
+        delayMicroseconds(15);
+        yield();
+        bytesInFifo = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      }
     } while (bytesInFifo < dataLength);
   }
 
   while (dataRead < dataLength) {
-    bytesInFifo = waitForBytesInFifo();
+    {
+      uint32_t start = millis();
+      bytesInFifo = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      while (bytesInFifo == 0) {
+        if (timeout && (millis() - start) >= timeout) {
+          setState(STATE_IDLE);
+          return STATUS_TIMEOUT;
+        }
+        delayMicroseconds(15);
+        yield();
+        bytesInFifo = readRegField(CC1101_REG_RXBYTES, 6, 0);
+      }
+    }
     uint8_t bytesToRead = min((uint8_t)(dataLength - dataRead), bytesInFifo);
     readRegBurst(CC1101_REG_FIFO, data + dataRead, bytesToRead);
     bytesRead += bytesToRead;
@@ -551,10 +599,16 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     return ret;
   }
 
+  #if (CC1101_APPEND_STATUS)
   this->rssi = readReg(CC1101_REG_FIFO);
   uint8_t v = readReg(CC1101_REG_FIFO);
   this->lqi = v & 0x7f;
+  #else
+  this->rssi = readReg(CC1101_REG_RSSI);
+  uint8_t v = readReg(CC1101_REG_LQI);
+  this->lqi = v & 0x7f;
 
+  #endif
   flushRxBuffer();
 
   bool crc_ok = (v >> 7) & 1;

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -20,6 +20,8 @@
 #define CC1101_VERSION            0x14
 #define CC1101_VERSION_LEGACY     0x04
 
+#define CC1101_APPEND_STATUS      0 /* Whether to append RSSI and LQI to the end of the payload. */
+
 /* Configuration registers */
 #define CC1101_REG_IOCFG2         0x00  /* GDO2 output pin configuration */
 #define CC1101_REG_IOCFG1         0x01  /* GDO1 output pin configuration */
@@ -116,7 +118,8 @@ enum Status {
   STATUS_LENGTH_TOO_BIG,
   STATUS_CRC_MISMATCH,
   STATUS_TXFIFO_UNDERFLOW,
-  STATUS_RXFIFO_OVERFLOW
+  STATUS_RXFIFO_OVERFLOW,
+  STATUS_TIMEOUT,
 };
 
 enum State {
@@ -215,7 +218,7 @@ class Radio {
   void setSyncWord(uint16_t sync);
 
   Status transmit(uint8_t *data, size_t length, uint8_t addr = 0);
-  Status receive(uint8_t *data, size_t length, size_t *read = nullptr, uint8_t addr = 0);
+  Status receive(uint8_t *data, size_t length, size_t *read = nullptr, uint8_t addr = 0, uint32_t timeout = 100);
   int8_t getRSSI();
   uint8_t getLQI();
 
@@ -253,7 +256,7 @@ class Radio {
   State currentState = STATE_IDLE;
   Modulation mod = MOD_2FSK;
   PacketLengthMode pktLenMode = PKT_LEN_MODE_FIXED;
-  AddressFilteringMode addrFilterMode = ADDR_FILTER_MODE_NONE;
+  AddressFilteringMode addrFilterMode = ADDR_FILTER_MODE_CHECK_BC_0;
   bool recvCallback = false;
 
   double freq = 433.5;


### PR DESCRIPTION
- Expose a timeout parameter for receive() (default 100 ms).

- Implement non‑blocking waits that return STATUS_TIMEOUT when the timeout is exceeded.

- Add a new STATUS_TIMEOUT enum.

- Update receive() to accept a timeout argument.

- Modify internal FIFO‑wait loops to honor the timeout and set the radio to IDLE when a timeout occurs.

- Add CC1101_APPEND_STATUS macro (default 0).

- Conditionally read RSSI/LQI from FIFO or registers based on the macro setting.

- Change default address filtering mode to CHECK_BC_0.

- Update PKTCTRL1 append‑status write logic to use the new macro.

- Add new example sketch: examples/Bidirectional_link demonstrating TX/RX with timeout support.

- Update README to document the new timeout parameter.