### PR TITLE
fix: make receive() more reliable (per CC1101 datasheet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Returns
 * `STATUS_LENGTH_TOO_SMALL` if `data` buffer is too small to hold the entire packet
 * `STATUS_CRC_MISMATCH` if the received CRC does not match the calculated CRC
 * `STATUS_RXFIFO_OVERFLOW` if the RX FIFO overflows due to unread incoming data
+* `STATUS_TIMEOUT` if no complete packet is received
 
 #### getRSSI
 ```cpp
@@ -266,4 +267,3 @@ The library was tested on the following boards:
  * [Arduino Pro Mini 3.3V](https://docs.arduino.cc/retired/boards/arduino-pro-mini/)
  * [Wemos D1 Mini ESP32](https://docs.platformio.org/en/stable/boards/espressif32/wemos_d1_mini32.html)
  * [ESP32C3 Super Mini](https://www.espboards.dev/esp32/esp32-c3-super-mini/)
-

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -71,7 +71,7 @@ void Radio::setModulation(Modulation mod) {
   writeRegField(CC1101_REG_MDMCFG2, (uint8_t)mod, 6, 4);
 
   setOutputPower(this->power);
-  
+
   if (mod == MOD_MSK || mod == MOD_4FSK) {
     setManchester(false);
   }
@@ -524,7 +524,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     the complete packet has been received before reading it out of the RX FIFO.
     Include the 2 appended status bytes (RSSI + CRC_OK|LQI) in the count.
   */
-  uint8_t totalRemaining = dataLength + 2;
+  uint16_t totalRemaining = (uint16_t)dataLength + 2;
   if (totalRemaining <= (CC1101_FIFO_SIZE - bytesRead)) {
     do {
       delayMicroseconds(15);
@@ -562,9 +562,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     }
   }
 
-  /* Read appended status bytes before waiting for IDLE. They are written
-     to the FIFO by the packet handler right after the last data byte. */
-  if (waitForBytesInFifo() == 0) {
+  if (waitForBytesInFifo(2) == 0) {
     if (currentState == STATE_RXFIFO_OVERFLOW) {
       flushRxBuffer();
       return STATUS_RXFIFO_OVERFLOW;
@@ -610,11 +608,10 @@ uint8_t Radio::readRxBytes() {
   return a;
 }
 
-/* Returns bytes in FIFO, or 0 on timeout / overflow. */
-uint8_t Radio::waitForBytesInFifo() {
+uint8_t Radio::waitForBytesInFifo(uint8_t minBytes) {
   unsigned long start = millis();
   uint8_t bytesInFifo = readRxBytes();
-  while (bytesInFifo == 0) {
+  while (bytesInFifo < minBytes) {
     if (currentState == STATE_RXFIFO_OVERFLOW ||
         (millis() - start > CC1101_RECV_TIMEOUT_MS)) {
       return 0;

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -59,8 +59,13 @@ void Radio::setRegs() {
   /* Automatically calibrate when going from IDLE to RX or TX. */
   writeRegField(CC1101_REG_MCSM0, 1, 5, 4);
 
-  /* Enable append status */
-  writeRegField(CC1101_REG_PKTCTRL1, 1, 2, 2);
+  /* Return to IDLE after a packet is received (MCSM1.RXOFF_MODE = IDLE) */
+  writeRegField(CC1101_REG_MCSM1, 0, 3, 2);
+
+  /* Append the 2 status bytes (RSSI + LQI/CRC_OK) to every packet and never
+     auto-flush the RX FIFO on CRC error; Both are assumptions receive() relies on. */
+  writeRegField(CC1101_REG_PKTCTRL1, 1, 2, 2);  /* APPEND_STATUS = 1 */
+  writeRegField(CC1101_REG_PKTCTRL1, 0, 3, 3);  /* CRC_AUTOFLUSH = 0 */
 
   /* Disable data whitening. */
   setDataWhitening(false);
@@ -473,13 +478,10 @@ Status Radio::transmit(uint8_t *data, size_t length, uint8_t addr) {
 }
 
 Status Radio::abortReceive() {
-  if (currentState == STATE_RXFIFO_OVERFLOW) {
-    flushRxBuffer();
-    return STATUS_RXFIFO_OVERFLOW;
-  }
+  bool overflow = rxFifoOverflowed();
   setState(STATE_IDLE);
   flushRxBuffer();
-  return STATUS_TIMEOUT;
+  return overflow ? STATUS_RXFIFO_OVERFLOW : STATUS_TIMEOUT;
 }
 
 Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) {
@@ -552,10 +554,6 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
 
     readRegBurst(CC1101_REG_FIFO, data + dataRead, bytesToRead);
     dataRead += bytesToRead;
-
-    if (currentState == STATE_RXFIFO_OVERFLOW) {
-      return abortReceive();
-    }
   }
 
   if (waitForBytesInFifo(2) == 0) {
@@ -567,14 +565,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   this->lqi = v & 0x7f;
   bool crc_ok = (v >> 7) & 1;
 
-  while (getState() != STATE_IDLE) {
-    if (currentState == STATE_RXFIFO_OVERFLOW) {
-      return abortReceive();
-    }
-    delayMicroseconds(50);
-    yield();
-  }
-
+  setState(STATE_IDLE);
   flushRxBuffer();
 
   if (read != nullptr) {
@@ -601,19 +592,31 @@ uint8_t Radio::readRxBytes() {
   return a;
 }
 
+/*
+  Reliable RX FIFO overflow check. RXBYTES.RXFIFO_OVERFLOW is a single-bit
+  field, which the SPI read-synchronization errata (SWRZ020E) lists as immune
+  to corruption - unlike the status-byte STATE field captured on every SPI transfer.
+*/
+bool Radio::rxFifoOverflowed() {
+  return readRegField(CC1101_REG_RXBYTES, 7, 7) != 0;
+}
+
 uint8_t Radio::waitForBytesInFifo(uint8_t minBytes) {
   unsigned long start = millis();
-  uint8_t bytesInFifo = readRxBytes();
-  while (bytesInFifo < minBytes) {
-    if (currentState == STATE_RXFIFO_OVERFLOW ||
-        (millis() - start > CC1101_RECV_TIMEOUT_MS)) {
+  while (true) {
+    if (rxFifoOverflowed()) {
+      return 0;
+    }
+    uint8_t bytesInFifo = readRxBytes();
+    if (bytesInFifo >= minBytes) {
+      return bytesInFifo;
+    }
+    if (millis() - start > CC1101_RECV_TIMEOUT_MS) {
       return 0;
     }
     delayMicroseconds(15);
     yield();
-    bytesInFifo = readRxBytes();
   }
-  return bytesInFifo;
 }
 
 void Radio::receiveCallback(void (*func)(void)) {

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -485,6 +485,10 @@ Status Radio::abortReceive() {
 }
 
 Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) {
+  if (read != nullptr) {
+    *read = 0;
+  }
+
   if (length > 255) {
     return STATUS_LENGTH_TOO_BIG;
   }

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -504,7 +504,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     headerBytes++;
   }
 
-  if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
+  if (addrFilterMode != ADDR_FILTER_MODE_NONE && dataLength > 0) {
     if (waitForBytesInFifo() == 0) {
       return abortReceive();
     }

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -478,7 +478,6 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   }
 
   uint8_t bytesInFifo, bytesRead = 0, curPktLen = 0;
-  Status ret = STATUS_OK;
 
   writeReg(CC1101_REG_ADDR, addr);
 
@@ -532,19 +531,14 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   */
   uint16_t totalRemaining = (uint16_t)dataLength + 2;
   if (totalRemaining <= (CC1101_FIFO_SIZE - bytesRead)) {
-    do {
-      delayMicroseconds(15);
-      yield();
-      bytesInFifo = waitForBytesInFifo();
-      if (bytesInFifo == 0) {
-        if (currentState == STATE_RXFIFO_OVERFLOW) {
-          flushRxBuffer();
-          return STATUS_RXFIFO_OVERFLOW;
-        }
-        setState(STATE_IDLE);
-        return STATUS_TIMEOUT;
+    if (waitForBytesInFifo((uint8_t)totalRemaining) == 0) {
+      if (currentState == STATE_RXFIFO_OVERFLOW) {
+        flushRxBuffer();
+        return STATUS_RXFIFO_OVERFLOW;
       }
-    } while (bytesInFifo < totalRemaining);
+      setState(STATE_IDLE);
+      return STATUS_TIMEOUT;
+    }
   }
 
   while (dataRead < dataLength) {

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -542,7 +542,13 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   }
 
   while (dataRead < dataLength) {
-    bytesInFifo = waitForBytesInFifo();
+    uint8_t remaining = dataLength - dataRead;
+    /*
+       Wait for at least 2 bytes. Per the datasheet the RX FIFO must never be emptied
+       before the last byte of the packet has been received, otherwise the last read
+       byte may be duplicated.
+    */
+    bytesInFifo = waitForBytesInFifo(2);
     if (bytesInFifo == 0) {
       if (currentState == STATE_RXFIFO_OVERFLOW) {
         flushRxBuffer();
@@ -551,7 +557,14 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
       setState(STATE_IDLE);
       return STATUS_TIMEOUT;
     }
-    uint8_t bytesToRead = min((uint8_t)(dataLength - dataRead), bytesInFifo);
+    uint8_t bytesToRead;
+    if ((uint16_t)bytesInFifo >= (uint16_t)remaining + 2) {
+      /* The whole packet, including the 2 appended status bytes, is already in the FIFO. */
+      bytesToRead = remaining;
+    } else {
+      /* Still receiving: read all but one of the available bytes. */
+      bytesToRead = min(remaining, (uint8_t)(bytesInFifo - 1));
+    }
     readRegBurst(CC1101_REG_FIFO, data + dataRead, bytesToRead);
     bytesRead += bytesToRead;
     dataRead += bytesToRead;

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -472,6 +472,16 @@ Status Radio::transmit(uint8_t *data, size_t length, uint8_t addr) {
   return ret;
 }
 
+Status Radio::abortReceive() {
+  if (currentState == STATE_RXFIFO_OVERFLOW) {
+    flushRxBuffer();
+    return STATUS_RXFIFO_OVERFLOW;
+  }
+  setState(STATE_IDLE);
+  flushRxBuffer();
+  return STATUS_TIMEOUT;
+}
+
 Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) {
   if (length > 255) {
     return STATUS_LENGTH_TOO_BIG;
@@ -491,12 +501,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     break;
     case PKT_LEN_MODE_VARIABLE:
       if (waitForBytesInFifo() == 0) {
-        if (currentState == STATE_RXFIFO_OVERFLOW) {
-          flushRxBuffer();
-          return STATUS_RXFIFO_OVERFLOW;
-        }
-        setState(STATE_IDLE);
-        return STATUS_TIMEOUT;
+        return abortReceive();
       }
       curPktLen = readReg(CC1101_REG_FIFO);
       bytesRead++;
@@ -507,12 +512,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
 
   if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
     if (waitForBytesInFifo() == 0) {
-      if (currentState == STATE_RXFIFO_OVERFLOW) {
-        flushRxBuffer();
-        return STATUS_RXFIFO_OVERFLOW;
-      }
-      setState(STATE_IDLE);
-      return STATUS_TIMEOUT;
+      return abortReceive();
     }
     (void)readReg(CC1101_REG_FIFO);
     bytesRead++;
@@ -521,6 +521,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
 
   if (dataLength > length) {
     setState(STATE_IDLE);
+    flushRxBuffer();
     return STATUS_LENGTH_TOO_SMALL;
   }
 
@@ -532,12 +533,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   uint16_t totalRemaining = (uint16_t)dataLength + 2;
   if (totalRemaining <= (CC1101_FIFO_SIZE - bytesRead)) {
     if (waitForBytesInFifo((uint8_t)totalRemaining) == 0) {
-      if (currentState == STATE_RXFIFO_OVERFLOW) {
-        flushRxBuffer();
-        return STATUS_RXFIFO_OVERFLOW;
-      }
-      setState(STATE_IDLE);
-      return STATUS_TIMEOUT;
+      return abortReceive();
     }
   }
 
@@ -550,12 +546,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     */
     bytesInFifo = waitForBytesInFifo(2);
     if (bytesInFifo == 0) {
-      if (currentState == STATE_RXFIFO_OVERFLOW) {
-        flushRxBuffer();
-        return STATUS_RXFIFO_OVERFLOW;
-      }
-      setState(STATE_IDLE);
-      return STATUS_TIMEOUT;
+      return abortReceive();
     }
     uint8_t bytesToRead;
     if ((uint16_t)bytesInFifo >= (uint16_t)remaining + 2) {
@@ -570,18 +561,12 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     dataRead += bytesToRead;
 
     if (currentState == STATE_RXFIFO_OVERFLOW) {
-      flushRxBuffer();
-      return STATUS_RXFIFO_OVERFLOW;
+      return abortReceive();
     }
   }
 
   if (waitForBytesInFifo(2) == 0) {
-    if (currentState == STATE_RXFIFO_OVERFLOW) {
-      flushRxBuffer();
-      return STATUS_RXFIFO_OVERFLOW;
-    }
-    setState(STATE_IDLE);
-    return STATUS_TIMEOUT;
+    return abortReceive();
   }
 
   this->rssi = readReg(CC1101_REG_FIFO);
@@ -591,8 +576,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
 
   while (getState() != STATE_IDLE) {
     if (currentState == STATE_RXFIFO_OVERFLOW) {
-      flushRxBuffer();
-      return STATUS_RXFIFO_OVERFLOW;
+      return abortReceive();
     }
     delayMicroseconds(50);
     yield();
@@ -614,10 +598,13 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
 uint8_t Radio::readRxBytes() {
   uint8_t a = readRegField(CC1101_REG_RXBYTES, 6, 0);
   uint8_t b;
-  do {
+  for (uint8_t i = 0; i < CC1101_RXBYTES_MAX_READS; i++) {
     b = a;
     a = readRegField(CC1101_REG_RXBYTES, 6, 0);
-  } while (a != b);
+    if (a == b) {
+      break;
+    }
+  }
   return a;
 }
 

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -487,35 +487,29 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     return STATUS_LENGTH_TOO_BIG;
   }
 
-  uint8_t bytesInFifo, bytesRead = 0, curPktLen = 0;
-
   writeReg(CC1101_REG_ADDR, addr);
 
   setState(STATE_IDLE);
   flushRxBuffer();
   setState(STATE_RX);
 
-  switch (pktLenMode) {
-    case PKT_LEN_MODE_FIXED:
-      curPktLen = this->pktLen;
-    break;
-    case PKT_LEN_MODE_VARIABLE:
-      if (waitForBytesInFifo() == 0) {
-        return abortReceive();
-      }
-      curPktLen = readReg(CC1101_REG_FIFO);
-      bytesRead++;
-    break;
-  }
+  uint8_t headerBytes = 0;
+  uint8_t dataLength = this->pktLen;
 
-  uint8_t dataRead = 0, dataLength = curPktLen;
+  if (pktLenMode == PKT_LEN_MODE_VARIABLE) {
+    if (waitForBytesInFifo() == 0) {
+      return abortReceive();
+    }
+    dataLength = readReg(CC1101_REG_FIFO);
+    headerBytes++;
+  }
 
   if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
     if (waitForBytesInFifo() == 0) {
       return abortReceive();
     }
     (void)readReg(CC1101_REG_FIFO);
-    bytesRead++;
+    headerBytes++;
     dataLength--;
   }
 
@@ -530,34 +524,33 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     the complete packet has been received before reading it out of the RX FIFO.
     Include the 2 appended status bytes (RSSI + CRC_OK|LQI) in the count.
   */
-  uint16_t totalRemaining = (uint16_t)dataLength + 2;
-  if (totalRemaining <= (CC1101_FIFO_SIZE - bytesRead)) {
-    if (waitForBytesInFifo((uint8_t)totalRemaining) == 0) {
+  uint16_t fullPacket = (uint16_t)dataLength + 2;
+  if (fullPacket <= (CC1101_FIFO_SIZE - headerBytes)) {
+    if (waitForBytesInFifo((uint8_t)fullPacket) == 0) {
       return abortReceive();
     }
   }
 
+  uint8_t dataRead = 0;
   while (dataRead < dataLength) {
     uint8_t remaining = dataLength - dataRead;
-    /*
-       Wait for at least 2 bytes. Per the datasheet the RX FIFO must never be emptied
-       before the last byte of the packet has been received, otherwise the last read
-       byte may be duplicated.
-    */
-    bytesInFifo = waitForBytesInFifo(2);
+
+    uint8_t bytesInFifo = waitForBytesInFifo(2);
     if (bytesInFifo == 0) {
       return abortReceive();
     }
-    uint8_t bytesToRead;
-    if ((uint16_t)bytesInFifo >= (uint16_t)remaining + 2) {
-      /* The whole packet, including the 2 appended status bytes, is already in the FIFO. */
-      bytesToRead = remaining;
-    } else {
-      /* Still receiving: read all but one of the available bytes. */
-      bytesToRead = min(remaining, (uint8_t)(bytesInFifo - 1));
-    }
+
+    /*
+      Per the datasheet the RX FIFO must never be emptied before the last byte
+      of the packet has been received, otherwise the last read byte may be
+      duplicated. Keep one byte back until the whole packet (payload + the 2
+      appended status bytes) is in the FIFO.
+    */
+    bool fullPacketInFifo = (uint16_t)bytesInFifo >= (uint16_t)remaining + 2;
+    uint8_t available = fullPacketInFifo ? bytesInFifo : (uint8_t)(bytesInFifo - 1);
+    uint8_t bytesToRead = min(remaining, available);
+
     readRegBurst(CC1101_REG_FIFO, data + dataRead, bytesToRead);
-    bytesRead += bytesToRead;
     dataRead += bytesToRead;
 
     if (currentState == STATE_RXFIFO_OVERFLOW) {

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -491,7 +491,11 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
       curPktLen = this->pktLen;
     break;
     case PKT_LEN_MODE_VARIABLE:
-      waitForBytesInFifo();
+      if (waitForBytesInFifo() == 0) {
+        setState(STATE_IDLE);
+        return currentState == STATE_RXFIFO_OVERFLOW ?
+          STATUS_RXFIFO_OVERFLOW : STATUS_TIMEOUT;
+      }
       curPktLen = readReg(CC1101_REG_FIFO);
       bytesRead++;
     break;
@@ -500,7 +504,11 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   uint8_t dataRead = 0, dataLength = curPktLen;
 
   if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
-    waitForBytesInFifo();
+    if (waitForBytesInFifo() == 0) {
+      setState(STATE_IDLE);
+      return currentState == STATE_RXFIFO_OVERFLOW ?
+        STATUS_RXFIFO_OVERFLOW : STATUS_TIMEOUT;
+    }
     (void)readReg(CC1101_REG_FIFO);
     bytesRead++;
     dataLength--;
@@ -514,67 +522,106 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   /*
     For packet lengths less than 64 bytes it is recommended to wait until
     the complete packet has been received before reading it out of the RX FIFO.
+    Include the 2 appended status bytes (RSSI + CRC_OK|LQI) in the count.
   */
-  if (dataLength <= (uint8_t)(CC1101_FIFO_SIZE - bytesRead)) {
+  uint8_t totalRemaining = dataLength + 2;
+  if (totalRemaining <= (CC1101_FIFO_SIZE - bytesRead)) {
     do {
       delayMicroseconds(15);
       yield();
       bytesInFifo = waitForBytesInFifo();
-    } while (bytesInFifo < dataLength);
+      if (bytesInFifo == 0) {
+        if (currentState == STATE_RXFIFO_OVERFLOW) {
+          flushRxBuffer();
+          return STATUS_RXFIFO_OVERFLOW;
+        }
+        setState(STATE_IDLE);
+        return STATUS_TIMEOUT;
+      }
+    } while (bytesInFifo < totalRemaining);
   }
 
   while (dataRead < dataLength) {
     bytesInFifo = waitForBytesInFifo();
+    if (bytesInFifo == 0) {
+      if (currentState == STATE_RXFIFO_OVERFLOW) {
+        flushRxBuffer();
+        return STATUS_RXFIFO_OVERFLOW;
+      }
+      setState(STATE_IDLE);
+      return STATUS_TIMEOUT;
+    }
     uint8_t bytesToRead = min((uint8_t)(dataLength - dataRead), bytesInFifo);
     readRegBurst(CC1101_REG_FIFO, data + dataRead, bytesToRead);
     bytesRead += bytesToRead;
     dataRead += bytesToRead;
 
     if (currentState == STATE_RXFIFO_OVERFLOW) {
-      ret = STATUS_RXFIFO_OVERFLOW;
       flushRxBuffer();
-      break;
+      return STATUS_RXFIFO_OVERFLOW;
     }
   }
 
-  while (getState() != STATE_IDLE) {
+  /* Read appended status bytes before waiting for IDLE. They are written
+     to the FIFO by the packet handler right after the last data byte. */
+  if (waitForBytesInFifo() == 0) {
     if (currentState == STATE_RXFIFO_OVERFLOW) {
-      ret = STATUS_RXFIFO_OVERFLOW;
       flushRxBuffer();
-      break;
+      return STATUS_RXFIFO_OVERFLOW;
     }
-    delayMicroseconds(50);
-    yield();
-  }
-
-  if (ret != STATUS_OK) {
-    return ret;
+    setState(STATE_IDLE);
+    return STATUS_TIMEOUT;
   }
 
   this->rssi = readReg(CC1101_REG_FIFO);
   uint8_t v = readReg(CC1101_REG_FIFO);
   this->lqi = v & 0x7f;
+  bool crc_ok = (v >> 7) & 1;
+
+  while (getState() != STATE_IDLE) {
+    if (currentState == STATE_RXFIFO_OVERFLOW) {
+      flushRxBuffer();
+      return STATUS_RXFIFO_OVERFLOW;
+    }
+    delayMicroseconds(50);
+    yield();
+  }
 
   flushRxBuffer();
-
-  bool crc_ok = (v >> 7) & 1;
-  if (!crc_ok) {
-    ret = STATUS_CRC_MISMATCH;
-  }
 
   if (read != nullptr) {
     *read = dataLength;
   }
 
-  return ret;
+  return crc_ok ? STATUS_OK : STATUS_CRC_MISMATCH;
 }
 
+/*
+  Read RXBYTES twice until the same value is returned, per datasheet errata.
+  A single SPI read can return a corrupt value due to synchronization issues.
+*/
+uint8_t Radio::readRxBytes() {
+  uint8_t a = readRegField(CC1101_REG_RXBYTES, 6, 0);
+  uint8_t b;
+  do {
+    b = a;
+    a = readRegField(CC1101_REG_RXBYTES, 6, 0);
+  } while (a != b);
+  return a;
+}
+
+/* Returns bytes in FIFO, or 0 on timeout / overflow. */
 uint8_t Radio::waitForBytesInFifo() {
-  uint8_t bytesInFifo = readRegField(CC1101_REG_RXBYTES, 6, 0);
+  unsigned long start = millis();
+  uint8_t bytesInFifo = readRxBytes();
   while (bytesInFifo == 0) {
+    if (currentState == STATE_RXFIFO_OVERFLOW ||
+        (millis() - start > CC1101_RECV_TIMEOUT_MS)) {
+      return 0;
+    }
     delayMicroseconds(15);
     yield();
-    bytesInFifo = readRegField(CC1101_REG_RXBYTES, 6, 0);
+    bytesInFifo = readRxBytes();
   }
   return bytesInFifo;
 }

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -492,9 +492,12 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     break;
     case PKT_LEN_MODE_VARIABLE:
       if (waitForBytesInFifo() == 0) {
+        if (currentState == STATE_RXFIFO_OVERFLOW) {
+          flushRxBuffer();
+          return STATUS_RXFIFO_OVERFLOW;
+        }
         setState(STATE_IDLE);
-        return currentState == STATE_RXFIFO_OVERFLOW ?
-          STATUS_RXFIFO_OVERFLOW : STATUS_TIMEOUT;
+        return STATUS_TIMEOUT;
       }
       curPktLen = readReg(CC1101_REG_FIFO);
       bytesRead++;
@@ -505,9 +508,12 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
 
   if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
     if (waitForBytesInFifo() == 0) {
+      if (currentState == STATE_RXFIFO_OVERFLOW) {
+        flushRxBuffer();
+        return STATUS_RXFIFO_OVERFLOW;
+      }
       setState(STATE_IDLE);
-      return currentState == STATE_RXFIFO_OVERFLOW ?
-        STATUS_RXFIFO_OVERFLOW : STATUS_TIMEOUT;
+      return STATUS_TIMEOUT;
     }
     (void)readReg(CC1101_REG_FIFO);
     bytesRead++;

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -236,7 +236,7 @@ class Radio {
   void chipDeselect();
   void waitReady();
   uint8_t readRxBytes();
-  uint8_t waitForBytesInFifo();
+  uint8_t waitForBytesInFifo(uint8_t minBytes = 1);
 
   void sendCmd(byte addr);
 

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -242,6 +242,7 @@ class Radio {
   void chipDeselect();
   void waitReady();
   uint8_t readRxBytes();
+  bool rxFifoOverflowed();
   uint8_t waitForBytesInFifo(uint8_t minBytes = 1);
   Status abortReceive();
 

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -10,9 +10,14 @@
 #define CC1101_SPI_DATA_MODE      SPI_MODE0  /* clk low, leading edge */
 
 #define CC1101_FIFO_SIZE          64    /* 64 B */
-#define CC1101_RECV_TIMEOUT_MS    5000  /* 5 s */
-#define CC1101_RXBYTES_MAX_READS  8     /* errata RXBYTES re-read cap */
 #define CC1101_CRYSTAL_FREQ       26    /* 26 MHz */
+
+#ifndef CC1101_RECV_TIMEOUT_MS
+#define CC1101_RECV_TIMEOUT_MS    5000  /* 5 s */
+#endif
+#ifndef CC1101_RXBYTES_MAX_READS
+#define CC1101_RXBYTES_MAX_READS  8     /* errata RXBYTES re-read cap */
+#endif
 
 #define CC1101_WRITE              0x00
 #define CC1101_READ               0x80
@@ -271,4 +276,3 @@ class Radio {
 };
 
 }
-

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -10,6 +10,7 @@
 #define CC1101_SPI_DATA_MODE      SPI_MODE0  /* clk low, leading edge */
 
 #define CC1101_FIFO_SIZE          64    /* 64 B */
+#define CC1101_RECV_TIMEOUT_MS    5000  /* 5 s */
 #define CC1101_CRYSTAL_FREQ       26    /* 26 MHz */
 
 #define CC1101_WRITE              0x00
@@ -116,7 +117,8 @@ enum Status {
   STATUS_LENGTH_TOO_BIG,
   STATUS_CRC_MISMATCH,
   STATUS_TXFIFO_UNDERFLOW,
-  STATUS_RXFIFO_OVERFLOW
+  STATUS_RXFIFO_OVERFLOW,
+  STATUS_TIMEOUT
 };
 
 enum State {
@@ -233,6 +235,7 @@ class Radio {
   void chipSelect();
   void chipDeselect();
   void waitReady();
+  uint8_t readRxBytes();
   uint8_t waitForBytesInFifo();
 
   void sendCmd(byte addr);

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -11,6 +11,7 @@
 
 #define CC1101_FIFO_SIZE          64    /* 64 B */
 #define CC1101_RECV_TIMEOUT_MS    5000  /* 5 s */
+#define CC1101_RXBYTES_MAX_READS  8     /* errata RXBYTES re-read cap */
 #define CC1101_CRYSTAL_FREQ       26    /* 26 MHz */
 
 #define CC1101_WRITE              0x00
@@ -237,6 +238,7 @@ class Radio {
   void waitReady();
   uint8_t readRxBytes();
   uint8_t waitForBytesInFifo(uint8_t minBytes = 1);
+  Status abortReceive();
 
   void sendCmd(byte addr);
 


### PR DESCRIPTION
Fixes three bugs in `receive()` that could make receiving fail or hang.

## Changes

- Stop the wait loop from hanging forever - before, if no packet came in, the code waited forever and the board froze. Now it gives up after a timeout and also stops on a FIFO overflow.

- Read the `RXBYTES` register twice - the datasheet says a single read can give a wrong value. We now read it until we get the same value twice, so the byte count is correct.

- Read the status bytes (RSSI, LQI, CRC) at the right time - they are now read right after the data, so they don't get lost.