### PR TITLE
fix: avoid digitalRead() warning on ESP32 with custom MISO pin

### DIFF
--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -2,7 +2,7 @@
 
 #if defined(ESP32) && \
     !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32C3)
-#include "driver/gpio.h"
+#include <driver/gpio.h>
 #endif
 
 #define log2(x) (log(x) / log(2))

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -1,5 +1,10 @@
 #include "cc1101.h"
 
+#if defined(ESP32) && \
+    !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#include "driver/gpio.h"
+#endif
+
 #define log2(x) (log(x) / log(2))
 
 using namespace CC1101;
@@ -836,7 +841,15 @@ void Radio::waitReady() {
   // goes low on CS unless in a low power mode. As this library does not (yet)
   // support low power modes, we can safely return immediately.
   return;
-  #endif
+  #elif defined(ESP32)
+  // On other ESP32 variants MISO is routed to the SPI peripheral through the
+  // GPIO matrix, so the Arduino digitalRead() HAL logs "IO N is not set as
+  // GPIO" warnings.
+  uint8_t pin = (miso == PIN_UNUSED) ? MISO : miso;
+  while (gpio_get_level((gpio_num_t)pin))
+    ;
+  #else
   while (digitalRead(MISO))
     ;
+  #endif
 }


### PR DESCRIPTION
Fixes https://github.com/mfurga/cc1101/issues/32.