### PR TITLE
ci: add cross-platform compile checks

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -31,7 +31,7 @@ jobs:
               - name: arduino:avr
             cli-compile-flags: |
               - --warnings
-              - all
+              - more
               - --build-property
               - compiler.cpp.extra_flags=-Werror
           - name: esp32

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -42,6 +42,10 @@ jobs:
             cli-compile-flags: |
               - --warnings
               - all
+              - --build-property
+              - compiler.cpp.extra_flags=-Werror
+              - --build-property
+              - compiler.warning_flags.all=-Wall -Wextra -Werror=unused-variable -Werror=unused-function -Werror=unused-but-set-variable -Werror=deprecated-declarations -Wno-error=unused-parameter -Wno-error=sign-compare
           - name: esp8266
             fqbn: "esp8266:esp8266:generic"
             platforms: |
@@ -50,6 +54,8 @@ jobs:
             cli-compile-flags: |
               - --warnings
               - all
+              - --build-property
+              - compiler.cpp.extra_flags=-Werror
           - name: rp2040-pico
             fqbn: "rp2040:rp2040:rpipico"
             platforms: |
@@ -58,14 +64,16 @@ jobs:
             cli-compile-flags: |
               - --warnings
               - all
+              - --build-property
+              - compiler.cpp.extra_flags=-Werror
           - name: teensy41
             fqbn: "teensy:avr:teensy41"
             platforms: |
               - name: teensy:avr
                 source-url: https://www.pjrc.com/teensy/package_teensy_index.json
             cli-compile-flags: |
-              - --warnings
-              - all
+              - --build-property
+              - build.flags.dep=-MMD -Werror
           - name: stm32-nucleo64
             fqbn: "STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F401RE"
             platforms: |
@@ -74,6 +82,8 @@ jobs:
             cli-compile-flags: |
               - --warnings
               - all
+              - --build-property
+              - compiler.cpp.extra_flags=-Werror
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Compile examples

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,90 @@
+name: Compile
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: arduino-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: arduino/arduino-lint-action@4de5fc895deecbda2f6b1cc05de7a8fdd5c4c51f # v2.0.0
+        with:
+          project-type: library
+          library-manager: update
+          compliance: strict
+
+  compile:
+    name: ${{ matrix.board.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - name: avr-mega
+            fqbn: "arduino:avr:mega"
+            platforms: |
+              - name: arduino:avr
+            cli-compile-flags: |
+              - --warnings
+              - all
+              - --build-property
+              - compiler.cpp.extra_flags=-Werror
+          - name: esp32
+            fqbn: "esp32:esp32:esp32"
+            platforms: |
+              - name: esp32:esp32
+                source-url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+            cli-compile-flags: |
+              - --warnings
+              - all
+          - name: esp8266
+            fqbn: "esp8266:esp8266:generic"
+            platforms: |
+              - name: esp8266:esp8266
+                source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
+            cli-compile-flags: |
+              - --warnings
+              - all
+          - name: rp2040-pico
+            fqbn: "rp2040:rp2040:rpipico"
+            platforms: |
+              - name: rp2040:rp2040
+                source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+            cli-compile-flags: |
+              - --warnings
+              - all
+          - name: teensy41
+            fqbn: "teensy:avr:teensy41"
+            platforms: |
+              - name: teensy:avr
+                source-url: https://www.pjrc.com/teensy/package_teensy_index.json
+            cli-compile-flags: |
+              - --warnings
+              - all
+          - name: stm32-nucleo64
+            fqbn: "STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F401RE"
+            platforms: |
+              - name: STMicroelectronics:stm32
+                source-url: https://raw.githubusercontent.com/stm32duino/BoardManagerFiles/main/package_stmicroelectronics_index.json
+            cli-compile-flags: |
+              - --warnings
+              - all
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Compile examples
+        uses: arduino/compile-sketches@8ac27e99289705c4abec832089575d687b859227 # v1.1.2
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            - source-path: ./
+          sketch-paths: |
+            - examples
+          cli-compile-flags: ${{ matrix.board.cli-compile-flags }}
+          enable-deltas-report: false
+          verbose: false

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,17 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    name: arduino-lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: arduino/arduino-lint-action@4de5fc895deecbda2f6b1cc05de7a8fdd5c4c51f # v2.0.0
-        with:
-          project-type: library
-          library-manager: update
-          compliance: strict
-
   compile:
     name: ${{ matrix.board.name }}
     runs-on: ubuntu-latest

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -781,7 +781,7 @@ void Radio::readRegBurst(uint8_t addr, uint8_t *buff, size_t size) {
 
   if (addr >= CC1101_REG_PARTNUM && addr <= CC1101_REG_RCCTRL0_STATUS) {
     /* Status registers cannot be accessed with the burst option. */
-    return;
+    return 123;
   }
 
   SPI.beginTransaction(spiSettings);

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -781,7 +781,7 @@ void Radio::readRegBurst(uint8_t addr, uint8_t *buff, size_t size) {
 
   if (addr >= CC1101_REG_PARTNUM && addr <= CC1101_REG_RCCTRL0_STATUS) {
     /* Status registers cannot be accessed with the burst option. */
-    return 123;
+    return;
   }
 
   SPI.beginTransaction(spiSettings);

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -545,7 +545,7 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     Include the 2 appended status bytes (RSSI + CRC_OK|LQI) in the count.
   */
   uint16_t fullPacket = (uint16_t)dataLength + 2;
-  if (fullPacket <= (CC1101_FIFO_SIZE - headerBytes)) {
+  if (fullPacket <= (uint16_t)(CC1101_FIFO_SIZE - headerBytes)) {
     if (waitForBytesInFifo((uint8_t)fullPacket) == 0) {
       return abortReceive();
     }


### PR DESCRIPTION
Adds CI that compiles the library and examples across platforms.

## Changes

- Adds compile check across six platforms (AVR, ESP32, ESP8266, RP2040, Teensy 4.1, STM32)
- Fixes a signed/unsigned comparison in `receive()`
