### PR TITLE
ci: add semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: lts/*
 
-      - run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/git @semantic-release/github
+      - run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/git @semantic-release/github conventional-changelog-conventionalcommits
 
       - run: semantic-release ${{ (inputs.dry_run || github.ref_name == 'ci/semantic-release') && '--dry-run --no-ci' || '' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: 4. Release
+
+on:
+  push:
+    branches: [main, ci/semantic-release]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (no release will be created)
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/git @semantic-release/github
+
+      - run: semantic-release ${{ (inputs.dry_run || github.ref_name == 'ci/semantic-release') && '--dry-run --no-ci' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: 4. Release
 
 on:
-  push:
-    branches: [main, ci/semantic-release]
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: 4. Release
 
 on:
+  push:
+    branches: [main, ci/semantic-release]
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: 4. Release
 
 on:
-  push:
-    branches: [main, ci/semantic-release]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -31,7 +29,7 @@ jobs:
 
       - run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/exec @semantic-release/git @semantic-release/github conventional-changelog-conventionalcommits
 
-      - run: semantic-release ${{ (inputs.dry_run || github.ref_name == 'ci/semantic-release') && '--dry-run --no-ci' || '' }}
+      - run: semantic-release ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: github-actions[bot]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["ci/semantic-release"],
+  "branches": ["main"],
   "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main", "ci/semantic-release"],
+  "branches": ["ci/semantic-release"],
   "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,26 @@
 {
-  "branches": ["main", "ci/semantic-release"],
+  "branches": ["main"],
   "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          {"type": "feat", "section": "Added"},
+          {"type": "fix", "section": "Fixed"},
+          {"type": "perf", "section": "Changed"},
+          {"type": "refactor", "section": "Changed"},
+          {"type": "revert", "section": "Fixed"},
+          {"type": "docs", "hidden": true},
+          {"type": "style", "hidden": true},
+          {"type": "chore", "hidden": true},
+          {"type": "test", "hidden": true},
+          {"type": "build", "hidden": true},
+          {"type": "ci", "hidden": true}
+        ]
+      }
+    }],
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", "ci/semantic-release"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,18 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    ["@semantic-release/exec", {
+      "prepareCmd": "jq --arg v '${nextRelease.version}' '.version = $v' library.json > library.json.tmp && mv library.json.tmp library.json && sed -i 's/^version=.*/version=${nextRelease.version}/' library.properties"
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "library.json", "library.properties"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main", "ci/semantic-release"],
+  "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", "ci/semantic-release"],
   "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2023 Mateusz Furga
 // SPDX-License-Identifier: MIT
-// dummy
 
 #include "cc1101.h"  // NOLINT(build/include_subdir)
 

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2023 Mateusz Furga
 // SPDX-License-Identifier: MIT
+// dummy
 
 #include "cc1101.h"  // NOLINT(build/include_subdir)
 


### PR DESCRIPTION
Adds automated releases using semantic-release.

Changes:

- Adds a release workflow triggered manually
- Adds `.releaserc.json` with changelog, version bump, git commit, and GitHub release steps
- Generates changelog entries following Keep a Changelog
