### PR TITLE
feat: add non-blocking RX and TX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The CC1101 module uses the SPI interface for communication. The SI, SO, SCLK pin
 
 On an ESP32 any GPIOs can be used, you can specify alternate ones in the constructor.
 
-The CC1101 exposes also two general purpose pins (GDO0, GDO2) which can be used to interrupt the MCU on certain events (e.g. RX FIFO is filled). They are optional and not required for proper work.
+The CC1101 also exposes two general-purpose pins (GDO0 and GDO2) that can trigger MCU interrupts on specific events (such as when the RX FIFO fills up). Using these pins is optional for basic operations, but GDO0 must be connected to an interrupt-capable pin on the MCU and configured in the constructor if you want to use the non-blocking RX/TX APIs.
 
 
 ## Software reference
@@ -87,7 +87,7 @@ Sets the RF output power (in dBm). Allowed output powers: -30, -20, -15, -10, 0,
 ```cpp
 Status transmit(uint8_t *data, size_t length, uint8_t addr = 0)
 ```
-Transmits the data. The `addr` parameter is used when the address filtering mode is enabled.
+Transmits the data. This method blocks until the transmission is complete or times out. The `addr` parameter is used when the address filtering mode is enabled.
 
 Returns
 * `STATUS_LENGTH_TOO_BIG` if `length` parameter is greater than 255, or if the `length` is greater than required in fixed packet mode
@@ -95,17 +95,99 @@ Returns
 * `STATUS_TXFIFO_UNDERFLOW` if the TX FIFO buffer runs out of data during transmission
 * `STATUS_TIMEOUT` if the packet is not fully transmitted within the timeout
 
+#### startTransmit
+```cpp
+Status startTransmit(uint8_t *data, size_t length, uint8_t addr = 0)
+```
+Starts a non-blocking transmission. The entire packet (including payload, optional address, and optional length byte) must fit within the 64-byte TX FIFO buffer. For longer payloads, use the blocking `transmit()` method instead.
+
+> [!IMPORTANT]
+> The methods `startTransmit()`, `setTransmitAction()`, `clearTransmitAction()`, and `finishTransmit()` form the non-blocking transmission API and are designed to be used together. Do not mix the blocking `transmit()` method with these non-blocking transmission methods.
+
+Returns
+* `STATUS_LENGTH_TOO_BIG` if the total packet length is greater than 255, or if it exceeds the 64-byte TX FIFO capacity, or if the `length` is greater than required in fixed packet mode
+* `STATUS_LENGTH_TOO_SMALL` if the `length` is smaller than required in fixed packet mode
+* `STATUS_OK` if transmission has successfully started
+
+#### setTransmitAction
+```cpp
+Status setTransmitAction(void (*func)(void))
+```
+Registers an interrupt callback function to be executed when the transmission is complete. The function uses the GDO0 pin to detect the falling edge of the sync word signal.
+
+Returns
+* `STATUS_INVALID_PARAM` if GDO0 was not configured
+* `STATUS_BAD_STATE` if sync word transmission is disabled (sync mode is set to `SYNC_MODE_NO_PREAMBLE` or `SYNC_MODE_NO_PREAMBLE_CS`)
+* `STATUS_OK` on success
+
+#### clearTransmitAction
+```cpp
+void clearTransmitAction()
+```
+Detaches the interrupt callback for transmission on the GDO0 pin.
+
+#### finishTransmit
+```cpp
+Status finishTransmit()
+```
+Finalizes the non-blocking transmission, transitions the radio state back to idle, and flushes the TX buffer.
+
+Returns
+* `STATUS_TXFIFO_UNDERFLOW` if the TX FIFO underflowed during transmission
+* `STATUS_OK` on success
+
 #### receive
 ```cpp
 Status receive(uint8_t *data, size_t length, size_t *read = nullptr, uint8_t addr = 0)
 ```
-Receives the data. The `read` parameter indicates the number of bytes actually received. The `addr` parameter is used when the address filtering mode is enabled.
+Receives the data. This method blocks until a packet is received or times out. The `read` parameter indicates the number of bytes actually received. The `addr` parameter is used when the address filtering mode is enabled.
 
 Returns
 * `STATUS_LENGTH_TOO_BIG` if the `length` parameter is greater than 255
 * `STATUS_LENGTH_TOO_SMALL` if `data` buffer is too small to hold the entire packet
 * `STATUS_CRC_MISMATCH` if the received CRC does not match the calculated CRC
 * `STATUS_RXFIFO_OVERFLOW` if the RX FIFO overflows due to unread incoming data
+* `STATUS_TIMEOUT` if no complete packet is received
+
+#### startReceive
+```cpp
+Status startReceive(uint8_t addr = 0)
+```
+Puts the radio into receive mode. If the GDO0 pin is configured, it configures GDO0 to assert when the RX FIFO is filled at or above the threshold, or when a packet ends.
+
+> [!IMPORTANT]
+> The methods `startReceive()`, `setReceiveAction()`, `clearReceiveAction()`, and `readData()` form the non-blocking reception API and are designed to be used together. Do not mix the blocking `receive()` method with these non-blocking reception methods.
+
+Returns
+* `STATUS_OK` on success
+
+#### setReceiveAction
+```cpp
+Status setReceiveAction(void (*func)(void))
+```
+Registers an interrupt callback function to be executed when the GDO0 pin transitions to high (rising edge), indicating that the RX FIFO threshold is reached or a packet has been fully received.
+
+Returns
+* `STATUS_INVALID_PARAM` if GDO0 was not configured
+* `STATUS_OK` on success
+
+#### clearReceiveAction
+```cpp
+void clearReceiveAction()
+```
+Detaches the interrupt callback for packet receipt on the GDO0 pin.
+
+#### readData
+```cpp
+Status readData(uint8_t *data, size_t length, size_t *read = nullptr)
+```
+Reads the received packet payload from the RX FIFO into the provided buffer `data`. The `read` parameter indicates the actual number of bytes read.
+
+Returns
+* `STATUS_LENGTH_TOO_BIG` if the requested `length` is greater than 255
+* `STATUS_LENGTH_TOO_SMALL` if the `data` buffer is too small to hold the received packet
+* `STATUS_CRC_MISMATCH` if the received CRC does not match the calculated CRC
+* `STATUS_RXFIFO_OVERFLOW` if the RX FIFO overflowed
 * `STATUS_TIMEOUT` if no complete packet is received
 
 #### getRSSI

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ The CC1101 module uses the SPI interface for communication. The SI, SO, SCLK pin
 
 On an ESP32 any GPIOs can be used, you can specify alternate ones in the constructor.
 
-The CC1101 also exposes two general-purpose pins (GDO0 and GDO2) that can trigger MCU interrupts on specific events (such as when the RX FIFO fills up). Using these pins is optional for basic operations, but GDO0 must be connected to an interrupt-capable pin on the MCU and configured in the constructor if you want to use the non-blocking RX/TX APIs.
-
+The CC1101 also exposes two general-purpose pins (GDO0 and GDO2) that can trigger MCU interrupts on specific events (such as when the RX FIFO fills up). Using these pins is optional for basic operations, but GDO0 must be connected to an interrupt-capable pin on the MCU if you want to use the interrupt-driven (callback-based) non-blocking RX/TX APIs.
 
 ## Software reference
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Starts a non-blocking transmission. The entire packet (including payload, option
 > The methods `startTransmit()`, `setTransmitAction()`, `clearTransmitAction()`, and `finishTransmit()` form the non-blocking transmission API and are designed to be used together. Do not mix the blocking `transmit()` method with these non-blocking transmission methods.
 
 Returns
-* `STATUS_LENGTH_TOO_BIG` if the total packet length is greater than 255, or if it exceeds the 64-byte TX FIFO capacity, or if the `length` is greater than required in fixed packet mode
+* `STATUS_LENGTH_TOO_BIG` if the total packet length is greater than 64-byte TX FIFO capacity, or if the `length` is greater than required in fixed packet mode
 * `STATUS_LENGTH_TOO_SMALL` if the `length` is smaller than required in fixed packet mode
 * `STATUS_OK` if transmission has successfully started
 

--- a/examples/Blocking/Receive/Receive.ino
+++ b/examples/Blocking/Receive/Receive.ino
@@ -1,9 +1,13 @@
+// Blocking receive example, standard FIFO packet mode.
+
 #include <Arduino.h>
 #include <cc1101.h>
 
 using namespace CC1101;
 
-Radio radio(/* cs pin */ 10);
+#define CS_PIN    10
+
+Radio radio(/* cs */ CS_PIN);
 
 void setup() {
   Serial.begin(115200);

--- a/examples/Blocking/Transmit/Transmit.ino
+++ b/examples/Blocking/Transmit/Transmit.ino
@@ -1,9 +1,13 @@
+// Blocking transmit example, standard FIFO packet mode.
+
 #include <Arduino.h>
 #include <cc1101.h>
 
 using namespace CC1101;
 
-Radio radio(/* cs pin */ 10);
+#define CS_PIN    10
+
+Radio radio(/* cs */ CS_PIN);
 
 void setup() {
   Serial.begin(115200);

--- a/examples/Interrupt/Receive/Receive.ino
+++ b/examples/Interrupt/Receive/Receive.ino
@@ -1,0 +1,87 @@
+// Non-blocking (interrupt-driven) receive example, standard FIFO packet mode.
+
+#include <Arduino.h>
+#include <cc1101.h>
+
+using namespace CC1101;
+
+#define CS_PIN    10
+#define GDO0_PIN  2  // must be an interrupt-capable pin
+
+Radio radio(/* cs */ CS_PIN, /* gd0 */ GDO0_PIN);
+
+volatile bool packetReceived = false;
+
+#if defined(ESP8266) || defined(ESP32)
+IRAM_ATTR
+#endif
+void onReceive() {  // keep ISRs tiny: just set a flag
+  packetReceived = true;
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(3000);
+  Serial.println(F("Starting ..."));
+  delay(1000);
+
+  if (radio.begin() == STATUS_CHIP_NOT_FOUND) {
+    Serial.println(F("Chip not found!"));
+    while (true) { delay(1000); }
+  }
+
+  radio.setModulation(MOD_ASK_OOK);
+  radio.setFrequency(433.8);
+  radio.setDataRate(10);
+  radio.setOutputPower(10);
+
+  radio.setPacketLengthMode(PKT_LEN_MODE_VARIABLE);
+  radio.setAddressFilteringMode(ADDR_FILTER_MODE_NONE);
+  radio.setPreambleLength(64);
+  radio.setSyncWord(0x1234);
+  radio.setSyncMode(SYNC_MODE_16_16);
+  radio.setCrc(true);
+  radio.setDataWhitening(true);
+  radio.setManchester(false);
+  radio.setFEC(false);
+
+  radio.setReceiveAction(onReceive);
+  radio.startReceive();
+
+  Serial.println(F("Listening ..."));
+}
+
+void loop() {
+  if (!packetReceived) {
+    // ... loop() is free to do other work here
+    static unsigned long lastBeat = 0;
+    if (millis() - lastBeat >= 200) {
+      lastBeat = millis();
+      Serial.println(F("Doing other work while waiting ..."));
+    }
+    return;
+  }
+  packetReceived = false;
+
+  char buff[32];
+  size_t read;
+  Status status = radio.readData((uint8_t *)buff, sizeof(buff) - 1, &read);
+
+  if (status == STATUS_OK) {
+    buff[read] = '\0';
+    Serial.print(F("Data: "));
+    Serial.println(buff);
+    Serial.print(F("RSSI: "));
+    Serial.print(radio.getRSSI());
+    Serial.println(F(" dBm"));
+    Serial.print(F("LQI: "));
+    Serial.println(radio.getLQI());
+  } else if (status == STATUS_CRC_MISMATCH) {
+    Serial.println(F("CRC mismatch!"));
+  } else {
+    Serial.print(F("Error: "));
+    Serial.println(status);
+  }
+
+  radio.startReceive();
+}

--- a/examples/Interrupt/Receive/Receive.ino
+++ b/examples/Interrupt/Receive/Receive.ino
@@ -45,7 +45,12 @@ void setup() {
   radio.setManchester(false);
   radio.setFEC(false);
 
-  radio.setReceiveAction(onReceive);
+  Status status = radio.setReceiveAction(onReceive);
+  if (status != STATUS_OK) {
+    Serial.print(F("setReceiveAction error: "));
+    Serial.println(status);
+    while (true) { delay(1000); }
+  }
   radio.startReceive();
 
   Serial.println(F("Listening ..."));
@@ -59,6 +64,7 @@ void loop() {
       lastBeat = millis();
       Serial.println(F("Doing other work while waiting ..."));
     }
+    yield();
     return;
   }
   packetReceived = false;

--- a/examples/Interrupt/Transmit/Transmit.ino
+++ b/examples/Interrupt/Transmit/Transmit.ino
@@ -1,0 +1,89 @@
+// Non-blocking (interrupt-driven) transmit example, standard FIFO packet mode.
+
+#include <Arduino.h>
+#include <cc1101.h>
+
+using namespace CC1101;
+
+#define CS_PIN    10
+#define GDO0_PIN  15  // must be an interrupt-capable pin
+
+Radio radio(/* cs */ CS_PIN, /* gd0 */ GDO0_PIN);
+
+volatile bool packetSent = false;
+
+#if defined(ESP8266) || defined(ESP32)
+IRAM_ATTR
+#endif
+void onTransmit() {  // keep ISRs tiny: just set a flag
+  packetSent = true;
+}
+
+int counter = 0;
+
+void setup() {
+  Serial.begin(115200);
+  delay(3000);
+  Serial.println(F("Starting ..."));
+  delay(1000);
+
+  if (radio.begin() == STATUS_CHIP_NOT_FOUND) {
+    Serial.println(F("Chip not found!"));
+    while (true) { delay(1000); }
+  }
+
+  radio.setModulation(MOD_ASK_OOK);
+  radio.setFrequency(433.8);
+  radio.setDataRate(10);
+  radio.setOutputPower(10);
+
+  radio.setPacketLengthMode(PKT_LEN_MODE_VARIABLE);
+  radio.setAddressFilteringMode(ADDR_FILTER_MODE_NONE);
+  radio.setPreambleLength(64);
+  radio.setSyncWord(0x1234);
+  radio.setSyncMode(SYNC_MODE_16_16);
+  radio.setCrc(true);
+  radio.setDataWhitening(true);
+  radio.setManchester(false);
+  radio.setFEC(false);
+
+  radio.setTransmitAction(onTransmit);
+}
+
+void loop() {
+  String data = "Hello #" + String(counter++);
+
+  Serial.print(F("Transmitting: "));
+  Serial.println(data);
+
+  Status status = radio.startTransmit((uint8_t *)data.c_str(), data.length());
+  if (status != STATUS_OK) {
+    Serial.print(F("startTransmit error: "));
+    Serial.println(status);
+    delay(1000);
+    return;
+  }
+
+  // ... loop() is free to do other work while the packet is sent
+  unsigned long lastBeat = 0;
+  while (!packetSent) {
+    if (millis() - lastBeat >= 50) {
+      lastBeat = millis();
+      Serial.println(F("Doing other work while transmitting ..."));
+    }
+    yield();
+  }
+
+  packetSent = false;
+  status = radio.finishTransmit();
+
+  if (status == STATUS_OK) {
+    Serial.println(F("[OK]"));
+  } else {
+    Serial.print("[ERROR ");
+    Serial.print(status);
+    Serial.println("]");
+  }
+
+  delay(1000);
+}

--- a/examples/Interrupt/Transmit/Transmit.ino
+++ b/examples/Interrupt/Transmit/Transmit.ino
@@ -47,7 +47,12 @@ void setup() {
   radio.setManchester(false);
   radio.setFEC(false);
 
-  radio.setTransmitAction(onTransmit);
+  Status status = radio.setTransmitAction(onTransmit);
+  if (status != STATUS_OK) {
+    Serial.print(F("setTransmitAction error: "));
+    Serial.println(status);
+    while (true) { delay(1000); }
+  }
 }
 
 void loop() {

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -75,8 +75,8 @@ void Radio::setRegs() {
   writeRegField(CC1101_REG_PKTCTRL1, 1, 2, 2);  /* APPEND_STATUS = 1 */
   writeRegField(CC1101_REG_PKTCTRL1, 0, 3, 3);  /* CRC_AUTOFLUSH = 0 */
 
-  /* RX FIFO threshold = 64 (max) */
-  writeRegField(CC1101_REG_FIFOTHR, 0x0f, 3, 0);
+  /* RX FIFO threshold = 48 bytes (TX FIFO threshold = 17 bytes) */
+  writeRegField(CC1101_REG_FIFOTHR, 0x0b, 3, 0);
 
   /* Disable data whitening. */
   setDataWhitening(false);

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -75,8 +75,8 @@ void Radio::setRegs() {
   writeRegField(CC1101_REG_PKTCTRL1, 1, 2, 2);  /* APPEND_STATUS = 1 */
   writeRegField(CC1101_REG_PKTCTRL1, 0, 3, 3);  /* CRC_AUTOFLUSH = 0 */
 
-  /* RX FIFO threshold = 48 bytes (TX FIFO threshold = 17 bytes) */
-  writeRegField(CC1101_REG_FIFOTHR, 0x0b, 3, 0);
+  /* RX FIFO threshold = 40 bytes (TX FIFO threshold = 25 bytes) */
+  writeRegField(CC1101_REG_FIFOTHR, 0x09, 3, 0);
 
   /* Disable data whitening. */
   setDataWhitening(false);

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -75,6 +75,9 @@ void Radio::setRegs() {
   writeRegField(CC1101_REG_PKTCTRL1, 1, 2, 2);  /* APPEND_STATUS = 1 */
   writeRegField(CC1101_REG_PKTCTRL1, 0, 3, 3);  /* CRC_AUTOFLUSH = 0 */
 
+  /* RX FIFO threshold = 64 (max) */
+  writeRegField(CC1101_REG_FIFOTHR, 0x0f, 3, 0);
+
   /* Disable data whitening. */
   setDataWhitening(false);
 }
@@ -378,6 +381,11 @@ void Radio::setAddressFilteringMode(AddressFilteringMode mode) {
   writeRegField(CC1101_REG_PKTCTRL1, (uint8_t)mode, 1, 0);
 }
 
+void Radio::setGdoConfig(GdoPin pin, GdoConfig cfg) {
+  uint8_t reg = (pin == GDO2) ? CC1101_REG_IOCFG2 : CC1101_REG_IOCFG0;
+  writeRegField(reg, (uint8_t)cfg, 5, 0);
+}
+
 void Radio::setCrc(bool enable) {
   writeRegField(CC1101_REG_PKTCTRL0, (uint8_t)enable, 2, 2);
 }
@@ -493,6 +501,88 @@ Status Radio::transmit(uint8_t *data, size_t length, uint8_t addr) {
   return STATUS_OK;
 }
 
+Status Radio::startTransmit(uint8_t *data, size_t length, uint8_t addr) {
+  size_t curPktLen = length;
+
+  if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
+    curPktLen++;
+  }
+
+  if (curPktLen > 255) {
+    return STATUS_LENGTH_TOO_BIG;
+  }
+
+  if (pktLenMode == PKT_LEN_MODE_FIXED) {
+    if (curPktLen < this->pktLen) {
+      return STATUS_LENGTH_TOO_SMALL;
+    }
+    if (curPktLen > this->pktLen) {
+      return STATUS_LENGTH_TOO_BIG;
+    }
+  }
+
+  /*
+    The whole packet (length byte + address byte + payload) must fit in the TX
+    FIFO: a non-blocking transmit cannot top the FIFO up as the chip drains it.
+    Use the blocking transmit() for longer payloads.
+  */
+  size_t fifoBytes = curPktLen + (pktLenMode == PKT_LEN_MODE_VARIABLE ? 1 : 0);
+  if (fifoBytes > CC1101_FIFO_SIZE) {
+    return STATUS_LENGTH_TOO_BIG;
+  }
+
+  setState(STATE_IDLE);
+  flushTxBuffer();
+
+  if (pktLenMode == PKT_LEN_MODE_VARIABLE) {
+    writeReg(CC1101_REG_FIFO, (uint8_t)curPktLen);
+  }
+
+  if (addrFilterMode != ADDR_FILTER_MODE_NONE) {
+    writeReg(CC1101_REG_FIFO, addr);
+  }
+
+  writeRegBurst(CC1101_REG_FIFO, data, length);
+
+  if (gd0 != PIN_UNUSED) {
+    setGdoConfig(GDO0, GDO_CFG_SYNC_WORD);
+  }
+
+  setState(STATE_TX);
+  return STATUS_OK;
+}
+
+Status Radio::setTransmitAction(void (*func)(void)) {
+  if (gd0 == PIN_UNUSED) {
+    return STATUS_INVALID_PARAM;
+  }
+  /* Check if the sync word is disabled */
+  if ((readRegField(CC1101_REG_MDMCFG2, 2, 0) & 0x03) == 0) {
+    return STATUS_BAD_STATE;
+  }
+  setGdoConfig(GDO0, GDO_CFG_SYNC_WORD);
+  attachInterrupt(digitalPinToInterrupt(gd0), func, FALLING);
+  return STATUS_OK;
+}
+
+void Radio::clearTransmitAction() {
+  if (gd0 == PIN_UNUSED) {
+    return;
+  }
+  detachInterrupt(digitalPinToInterrupt(gd0));
+}
+
+// bool Radio::transmitDone() {
+//   return getState() != STATE_TX;
+// }
+
+Status Radio::finishTransmit() {
+  bool underflow = txFifoUnderflowed();
+  setState(STATE_IDLE);
+  flushTxBuffer();
+  return underflow ? STATUS_TXFIFO_UNDERFLOW : STATUS_OK;
+}
+
 Status Radio::abortReceive() {
   bool overflow = rxFifoOverflowed();
   setState(STATE_IDLE);
@@ -500,7 +590,52 @@ Status Radio::abortReceive() {
   return overflow ? STATUS_RXFIFO_OVERFLOW : STATUS_TIMEOUT;
 }
 
+Status Radio::startReceive(uint8_t addr) {
+  writeReg(CC1101_REG_ADDR, addr);
+
+  setState(STATE_IDLE);
+  flushRxBuffer();
+
+  if (gd0 != PIN_UNUSED) {
+    setGdoConfig(GDO0, GDO_CFG_RX_FIFO_THR);
+  }
+
+  setState(STATE_RX);
+  return STATUS_OK;
+}
+
+Status Radio::setReceiveAction(void (*func)(void)) {
+  if (gd0 == PIN_UNUSED) {
+    return STATUS_INVALID_PARAM;
+  }
+  setGdoConfig(GDO0, GDO_CFG_RX_FIFO_THR);
+  attachInterrupt(digitalPinToInterrupt(gd0), func, RISING);
+  return STATUS_OK;
+}
+
+void Radio::clearReceiveAction() {
+  if (gd0 == PIN_UNUSED) {
+    return;
+  }
+  detachInterrupt(digitalPinToInterrupt(gd0));
+}
+
+// bool Radio::available() {
+//   if (rxFifoOverflowed()) {
+//     return true;
+//   }
+//   return getState() != STATE_RX && readFifoByteCount(CC1101_REG_RXBYTES) > 0;
+// }
+
 Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) {
+  Status status = startReceive(addr);
+  if (status != STATUS_OK) {
+    return status;
+  }
+  return readData(data, length, read);
+}
+
+Status Radio::readData(uint8_t *data, size_t length, size_t *read) {
   if (read != nullptr) {
     *read = 0;
   }
@@ -508,12 +643,6 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
   if (length > 255) {
     return STATUS_LENGTH_TOO_BIG;
   }
-
-  writeReg(CC1101_REG_ADDR, addr);
-
-  setState(STATE_IDLE);
-  flushRxBuffer();
-  setState(STATE_RX);
 
   uint8_t headerBytes = 0;
   uint8_t dataLength = this->pktLen;
@@ -570,8 +699,8 @@ Status Radio::receive(uint8_t *data, size_t length, size_t *read, uint8_t addr) 
     */
     bool fullPacketInFifo =
         static_cast<uint16_t>(bytesInFifo) >= static_cast<uint16_t>(remaining) + 2;
-    uint8_t available = fullPacketInFifo ? bytesInFifo : (uint8_t)(bytesInFifo - 1);
-    uint8_t bytesToRead = min(remaining, available);  // NOLINT(build/include_what_you_use)
+    uint8_t readable = fullPacketInFifo ? bytesInFifo : (uint8_t)(bytesInFifo - 1);
+    uint8_t bytesToRead = min(remaining, readable);  // NOLINT(build/include_what_you_use)
 
     readRegBurst(CC1101_REG_FIFO, data + dataRead, bytesToRead);
     dataRead += bytesToRead;
@@ -663,22 +792,6 @@ uint8_t Radio::waitForSpaceInFifo(uint8_t minSpace) {
     delayMicroseconds(15);
     yield();
   }
-}
-
-void Radio::receiveCallback(void (*func)(void)) {
-  /*
-    Associated to the RX FIFO: Asserts when RX FIFO is filled at or above
-    the RX FIFO threshold or the end of packet is reached. De-asserts when
-    the RX FIFO is empty.
-  */
-  writeRegField(CC1101_REG_IOCFG0, 1, 5, 0);
-
-  // TODO(mfurga): Move to other method.
-  flushRxBuffer();
-  setState(STATE_RX);
-
-  recvCallback = true;
-  attachInterrupt(digitalPinToInterrupt(gd0), func, RISING);
 }
 
 State Radio::getState() {

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -183,7 +183,7 @@ enum GdoPin {
 
 enum GdoConfig {
   GDO_CFG_RX_FIFO_THR       = 0x01, /* RX FIFO >= threshold or end of packet */
-  GDO_CFG_SYNC_WORD         = 0x06, /* asserts on sync, deasserts end of packet */
+  GDO_CFG_SYNC_WORD         = 0x06, /* asserts on sync, de-asserts at end of packet */
   GDO_CFG_HIGH_Z            = 0x2e, /* high impedance (3-state) */
 };
 

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -176,6 +176,17 @@ enum AddressFilteringMode {
   ADDR_FILTER_MODE_CHECK_BC_0_255 = 3 /* Address check, 0 and 255 broadcast */
 };
 
+enum GdoPin {
+  GDO0 = 0,  /* maps to IOCFG0 */
+  GDO2 = 2,  /* maps to IOCFG2 */
+};
+
+enum GdoConfig {
+  GDO_CFG_RX_FIFO_THR       = 0x01, /* RX FIFO >= threshold or end of packet */
+  GDO_CFG_SYNC_WORD         = 0x06, /* asserts on sync, deasserts end of packet */
+  GDO_CFG_HIGH_Z            = 0x2e, /* high impedance (3-state) */
+};
+
 class Radio {
  public:
 #ifdef ESP32
@@ -228,13 +239,28 @@ class Radio {
   Status setPreambleLength(uint8_t length);
   void setSyncWord(uint16_t sync);
 
+  /* Blocking transmit */
   Status transmit(uint8_t *data, size_t length, uint8_t addr = 0);
+
+  /* Non-blocking transmit */
+  Status startTransmit(uint8_t *data, size_t length, uint8_t addr = 0);
+  Status setTransmitAction(void (*func)(void));
+  void clearTransmitAction();
+  // bool transmitDone();
+  Status finishTransmit();
+
+  /* Blocking receive */
   Status receive(uint8_t *data, size_t length, size_t *read = nullptr, uint8_t addr = 0);
+
+  /* Non-blocking receive */
+  Status startReceive(uint8_t addr = 0);
+  Status setReceiveAction(void (*func)(void));
+  void clearReceiveAction();
+  // bool available();
+  Status readData(uint8_t *data, size_t length, size_t *read = nullptr);
+
   int8_t getRSSI();
   uint8_t getLQI();
-
-  void receiveCallback(void (*func)(void));
-
   uint8_t readRegField(uint8_t addr, uint8_t hi, uint8_t lo);
   uint8_t readReg(uint8_t addr);
   void readRegBurst(uint8_t addr, uint8_t *buff, size_t size);
@@ -244,6 +270,8 @@ class Radio {
   void writeRegBurst(uint8_t addr, uint8_t *data, size_t size);
 
  private:
+  void setGdoConfig(GdoPin pin, GdoConfig cfg);
+
   void chipSelect();
   void chipDeselect();
   void waitReady();
@@ -274,7 +302,6 @@ class Radio {
   Modulation mod = MOD_2FSK;
   PacketLengthMode pktLenMode = PKT_LEN_MODE_FIXED;
   AddressFilteringMode addrFilterMode = ADDR_FILTER_MODE_NONE;
-  bool recvCallback = false;
 
   double freq = 433.5;
   double drate = 4.0;


### PR DESCRIPTION
Adds non-blocking (interrupt-driven) RX and TX APIs.

Changes:

- Adds `startTransmit`, `setTransmitAction`, `clearTransmitAction`, and `finishTransmit` methods for non-blocking packet transmission
- Adds `startReceive`, `setReceiveAction`, `clearReceiveAction`, and `readData` methods for non-blocking packet reception
- Adds enums (GdoPin, GdoConfig) and internal helper `setGdoConfig` to manage GDO0/GDO2 pin behaviors
- Refactors the blocking `receive()` method to build on top of `startReceive()` and `readData()`
- Renames HelloWorld examples to Blocking examples
- Adds new non-blocking examples demonstrating interrupt-driven RX and TX
- Updates README.md with non-blocking API documentation
