### PR TITLE
docs: fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CC1101
 
-The Arduino library for the TI CC1101 sub-1 Ghz RF transceiver.
+The Arduino library for the TI CC1101 sub-1 GHz RF transceiver.
 
 CC1101 key features:
 * Modulations: ASK (OOK), 2-FSK, GFSK, 4-FSK, MSK
@@ -9,13 +9,13 @@ CC1101 key features:
 * Output power up to +12 dBm
 * Support for sync word detection, address check, flexible packet length, and automatic CRC handling
 
-For more information check out the [datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf).
+For more information, check out the [datasheet](https://www.ti.com/lit/ds/symlink/cc1101.pdf).
 
 ## Hardware connection
 
-The CC1101 module uses the SPI interface for communication. The SI, SO, SCLK pins should be connected to dedicated SPI pins on your Arduino board. The CSn can be connected to any digital pin.
+The CC1101 module uses the SPI interface for communication. The SI, SO, and SCLK pins should be connected to dedicated SPI pins on your Arduino board. The CSn can be connected to any digital pin.
 
-On an ESP32 any GPIOs can be used, you can specify alternate ones in the constructor.
+On an ESP32, any GPIOs can be used; you can specify alternate ones in the constructor.
 
 The CC1101 also exposes two general-purpose pins (GDO0 and GDO2) that can trigger MCU interrupts on specific events (such as when the RX FIFO fills up). Using these pins is optional for basic operations, but GDO0 must be connected to an interrupt-capable pin on the MCU if you want to use the interrupt-driven (callback-based) non-blocking RX/TX APIs.
 
@@ -42,7 +42,7 @@ Returns `STATUS_INVALID_PARAM` on bad frequency.
 ```cpp
 Status setFrequencyDeviation(double dev)
 ```
-Sets the frequency deviation. Allowed frequency deviation range: 1.587 to 380.859 kHz (assuming 26.0 MHz crystal frequency). For `MOD_ASK_OOK` modulation this setting has no effect.
+Sets the frequency deviation. Allowed frequency deviation range: 1.587 to 380.859 kHz (assuming 26.0 MHz crystal frequency). For `MOD_ASK_OOK` modulation, this setting has no effect.
 
 Returns `STATUS_INVALID_PARAM` on bad frequency deviation.
 
@@ -56,7 +56,7 @@ Sets the channel frequency. The channel frequency is multiplied by the channel s
 ```cpp
 Status setChannelSpacing(double sp)
 ```
-Sets the channel spacing frequency (in kHz). Allowed channel spacing range: 25.390 to 405.456 kHz (assuming 26.0 MHz crystal frequency).
+Sets the channel spacing (in kHz). Allowed channel spacing range: 25.390 to 405.456 kHz (assuming 26.0 MHz crystal frequency).
 
 Returns `STATUS_INVALID_PARAM` on bad channel spacing.
 
@@ -64,13 +64,13 @@ Returns `STATUS_INVALID_PARAM` on bad channel spacing.
 ```cpp
 Status setDataRate(double drate)
 ```
-Sets the data rate (in kBaud). The allowed data rate depends on the selected modulation (see General Characteristics Table in the datasheet).
+Sets the data rate (in kBaud). The allowed data rate depends on the selected modulation (see the General Characteristics Table in the datasheet).
 
 Returns `STATUS_INVALID_PARAM` on bad data rate.
 
 #### setRxBandwidth
 ```cpp
-Status setRxBandwidth(double bw);
+Status setRxBandwidth(double bw)
 ```
 Sets the receiver channel filter bandwidth (in kHz). Allowed bandwidth range: 58 to 812 kHz (assuming 26.0 MHz crystal frequency).
 
@@ -89,7 +89,7 @@ Status transmit(uint8_t *data, size_t length, uint8_t addr = 0)
 Transmits the data. This method blocks until the transmission is complete or times out. The `addr` parameter is used when the address filtering mode is enabled.
 
 Returns
-* `STATUS_LENGTH_TOO_BIG` if `length` parameter is greater than 255, or if the `length` is greater than required in fixed packet mode
+* `STATUS_LENGTH_TOO_BIG` if the `length` parameter is greater than 255, or if the `length` is greater than required in fixed packet mode
 * `STATUS_LENGTH_TOO_SMALL` if the `length` is smaller than required in fixed packet mode
 * `STATUS_TXFIFO_UNDERFLOW` if the TX FIFO buffer runs out of data during transmission
 * `STATUS_TIMEOUT` if the packet is not fully transmitted within the timeout
@@ -104,7 +104,7 @@ Starts a non-blocking transmission. The entire packet (including payload, option
 > The methods `startTransmit()`, `setTransmitAction()`, `clearTransmitAction()`, and `finishTransmit()` form the non-blocking transmission API and are designed to be used together. Do not mix the blocking `transmit()` method with these non-blocking transmission methods.
 
 Returns
-* `STATUS_LENGTH_TOO_BIG` if the total packet length is greater than 64-byte TX FIFO capacity, or if the `length` is greater than required in fixed packet mode
+* `STATUS_LENGTH_TOO_BIG` if the total packet length is greater than the 64-byte TX FIFO capacity, or if the `length` is greater than required in fixed packet mode
 * `STATUS_LENGTH_TOO_SMALL` if the `length` is smaller than required in fixed packet mode
 * `STATUS_OK` if transmission has successfully started
 
@@ -143,7 +143,7 @@ Receives the data. This method blocks until a packet is received or times out. T
 
 Returns
 * `STATUS_LENGTH_TOO_BIG` if the `length` parameter is greater than 255
-* `STATUS_LENGTH_TOO_SMALL` if `data` buffer is too small to hold the entire packet
+* `STATUS_LENGTH_TOO_SMALL` if the `data` buffer is too small to hold the entire packet
 * `STATUS_CRC_MISMATCH` if the received CRC does not match the calculated CRC
 * `STATUS_RXFIFO_OVERFLOW` if the RX FIFO overflows due to unread incoming data
 * `STATUS_TIMEOUT` if no complete packet is received
@@ -152,7 +152,7 @@ Returns
 ```cpp
 Status startReceive(uint8_t addr = 0)
 ```
-Puts the radio into receive mode. If the GDO0 pin is configured, it configures GDO0 to assert when the RX FIFO is filled at or above the threshold, or when a packet ends.
+Puts the radio into receive mode. When the GDO0 pin is configured, GDO0 is set to assert when the RX FIFO is filled at or above the threshold, or when a packet ends.
 
 > [!IMPORTANT]
 > The methods `startReceive()`, `setReceiveAction()`, `clearReceiveAction()`, and `readData()` form the non-blocking reception API and are designed to be used together. Do not mix the blocking `receive()` method with these non-blocking reception methods.
@@ -164,7 +164,7 @@ Returns
 ```cpp
 Status setReceiveAction(void (*func)(void))
 ```
-Registers an interrupt callback function to be executed when the GDO0 pin transitions to high (rising edge), indicating that the RX FIFO threshold is reached or a packet has been fully received.
+Registers an interrupt callback function to be executed when the GDO0 pin goes high (rising edge), indicating that the RX FIFO threshold is reached or a packet has been fully received.
 
 Returns
 * `STATUS_INVALID_PARAM` if GDO0 was not configured
@@ -214,13 +214,13 @@ void setSyncMode(SyncMode mode)
 Sets the sync word mode.
 
 * `SYNC_MODE_NO_PREAMBLE` - Disables preamble and sync word transmission in TX and preamble and sync word detection in RX.
-* `SYNC_MODE_15_16` - Enables 16-bit sync word transmission in TX and 16-bits sync word detection in RX. Only 15 of 16 bits need to match in RX.
-* `SYNC_MODE_16_16` - Enables 16-bit sync word transmission in TX and 16-bits sync word detection in RX. All 16 bits need to match in RX.
-* `SYNC_MODE_30_32` - Enables repeated sync word transmission in TX and 32-bits sync word detection in RX. Only 30 of 32 bits need to match in RX. The sync word will then be repeated twice.
+* `SYNC_MODE_15_16` - Enables 16-bit sync word transmission in TX and 16-bit sync word detection in RX. Only 15 of 16 bits need to match in RX.
+* `SYNC_MODE_16_16` - Enables 16-bit sync word transmission in TX and 16-bit sync word detection in RX. All 16 bits need to match in RX.
+* `SYNC_MODE_30_32` - Enables repeated sync word transmission in TX and 32-bit sync word detection in RX. Only 30 of 32 bits need to match in RX. The sync word is transmitted twice.
 * `SYNC_MODE_NO_PREAMBLE_CS` - Disables preamble and sync word transmission in TX and preamble and sync word detection in RX.
-* `SYNC_MODE_15_16_CS` - Enables 16-bit sync word transmission in TX and 16-bits sync word detection in RX. Only 15 of 16 bits need to match in RX. Requires carrier sense above threshold in addition to sync word.
-* `SYNC_MODE_16_16_CS` - Enables 16-bit sync word transmission in TX and 16-bits sync word detection in RX. All 16 bits need to match in RX. Requires carrier sense above threshold in addition to sync word.
-* `SYNC_MODE_30_32_CS` - Enables repeated sync word transmission in TX and 32-bits sync word detection in RX. Only 30 of 32 bits need to match in RX. The sync word will then be repeated twice. Requires carrier sense above threshold in addition to sync word.
+* `SYNC_MODE_15_16_CS` - Enables 16-bit sync word transmission in TX and 16-bit sync word detection in RX. Only 15 of 16 bits need to match in RX. Requires carrier sense above threshold in addition to sync word.
+* `SYNC_MODE_16_16_CS` - Enables 16-bit sync word transmission in TX and 16-bit sync word detection in RX. All 16 bits need to match in RX. Requires carrier sense above threshold in addition to sync word.
+* `SYNC_MODE_30_32_CS` - Enables repeated sync word transmission in TX and 32-bit sync word detection in RX. Only 30 of 32 bits need to match in RX. The sync word is transmitted twice. Requires carrier sense above threshold in addition to sync word.
 
 #### setPreambleLength
 ```cpp
@@ -242,8 +242,8 @@ void setPacketLengthMode(PacketLengthMode mode, uint8_t length = 255)
 ```
 Sets the packet length mode. Packet length types:
 
-* `PKT_LEN_MODE_FIXED` - Fixed packet length mode. The length field is not transmitted in TX and `length` parameter indicates the number of bytes that handler will accept in RX.
-* `PKT_LEN_MODE_VARIABLE` - Variable packet length mode. The length field is transmitted in TX. The packet handler assumes that the first byte (after the sync word) is the length byte and receives the number of bytes indicated by its value. The `length` parameter is used to set the maximum packet length allowed in RX. Any packet received with a length byte with a value greater than `length` will be discarded.
+* `PKT_LEN_MODE_FIXED` - Fixed packet length mode. The length field is not transmitted in TX and the `length` parameter indicates the number of bytes that the handler will accept in RX.
+* `PKT_LEN_MODE_VARIABLE` - Variable packet length mode. The length field is transmitted in TX. The packet handler assumes that the first byte (after the sync word) is the length byte and receives the number of bytes indicated by its value. The `length` parameter is used to set the maximum packet length allowed in RX. Any packet whose length byte exceeds `length` will be discarded.
 
 > [!IMPORTANT]
 > The library supports only packets up to 255 bytes.
@@ -256,7 +256,7 @@ Sets the address filtering mode.
 
 * `ADDR_FILTER_MODE_NONE` - Disables address transmission in TX and address checking in RX.
 * `ADDR_FILTER_MODE_CHECK` - Enables address transmission in TX and address checking in RX. No broadcast address.
-* `ADDR_FILTER_MODE_CHECK_BC_0` - Enables address transmission in TX and address checking in RX. Address 0 is broadcast address.
+* `ADDR_FILTER_MODE_CHECK_BC_0` - Enables address transmission in TX and address checking in RX. Address 0 is a broadcast address.
 * `ADDR_FILTER_MODE_CHECK_BC_0_255` - Enables address transmission in TX and address checking in RX. Addresses 0 and 255 are broadcast addresses.
 
 #### setCrc
@@ -272,7 +272,7 @@ void setDataWhitening(bool enable)
 
 Enables/disables data whitening.
 
-If whitening is enabled, everything following the sync words will be whitened. This is done before the optional FEC/Interleaver stage.
+If whitening is enabled, everything following the sync word will be whitened. This is done before the optional FEC/Interleaver stage.
 
 #### setManchester
 ```cpp
@@ -282,8 +282,7 @@ Status setManchester(bool enable)
 Enables/disables Manchester encoding in TX and Manchester decoding in RX.
 
 > [!NOTE]
-> Manchester encoding is not supported at the same time as using the FEC/Interleaver option or when using MSK
-and 4-FSK modulation.
+> Manchester encoding is not supported at the same time as using the FEC/Interleaver option or when using MSK and 4-FSK modulation.
 
 Returns `STATUS_BAD_STATE` if Manchester encoding cannot be enabled.
 


### PR DESCRIPTION
Fixes typos and grammatical errors in README.md.